### PR TITLE
Fix zone channel

### DIFF
--- a/ChannelManager.cpp
+++ b/ChannelManager.cpp
@@ -51,11 +51,7 @@ void ChannelManager::Initialize()
 			m_server_channel.emplace(m_logger, "server", server);
 		}
 
-		std::string_view shortName = pZoneInfo->ShortName;
-		if (!shortName.empty())
-		{
-			m_zone_channel.emplace(m_logger, "zone", shortName);
-		}
+		UpdateZoneChannel();
 
 		LoadPersistentChannels();
 	}
@@ -244,6 +240,23 @@ void ChannelManager::UpdateRaidChannel()
 	}
 }
 
+void ChannelManager::UpdateZoneChannel()
+{
+	if (GetGameState() != GAMESTATE_INGAME || !pZoneInfo || !pZoneInfo->ShortName[0])
+	{
+		m_zone_channel.reset();
+		return;
+	}
+
+	std::string zoneShort = pZoneInfo->ShortName;
+	to_lower(zoneShort);
+
+	if (!m_zone_channel || !ci_equals(m_zone_channel->GetSubName(), zoneShort))
+	{
+		m_zone_channel.emplace("zone", zoneShort);
+	}
+}
+
 void ChannelManager::SetGameState(int gameState)
 {
 	if (gameState != GAMESTATE_INGAME)
@@ -266,6 +279,12 @@ void ChannelManager::SetGameState(int gameState)
 			}
 		}
 	}
+
+	if (gameState == GAMESTATE_INGAME)
+	{
+		LoadPersistentChannels();
+		UpdateZoneChannel();
+	}
 }
 
 void ChannelManager::OnPulse()
@@ -278,6 +297,7 @@ void ChannelManager::OnPulse()
 			m_nextGroupUpdate = now + GROUP_UPDATE_INTERVAL;
 			UpdateGroupChannel();
 			UpdateRaidChannel();
+			UpdateZoneChannel();
 		}
 
 		if (m_channelINISection.empty())
@@ -295,14 +315,11 @@ void ChannelManager::OnBeginZone()
 
 void ChannelManager::OnEndZone()
 {
-	if (GetGameState() == GAMESTATE_INGAME)
-	{
-		std::string_view shortName = pZoneInfo->ShortName;
-		if (!shortName.empty())
-		{
-			m_zone_channel.emplace(m_logger, "zone", shortName);
-		}
-	}
+}
+
+void ChannelManager::OnZoned()
+{
+	UpdateZoneChannel();
 }
 
 } // namespace remote

--- a/ChannelManager.cpp
+++ b/ChannelManager.cpp
@@ -253,7 +253,7 @@ void ChannelManager::UpdateZoneChannel()
 
 	if (!m_zone_channel || !ci_equals(m_zone_channel->GetSubName(), zoneShort))
 	{
-		m_zone_channel.emplace("zone", zoneShort);
+		m_zone_channel.emplace(m_logger, "zone", zoneShort);
 	}
 }
 

--- a/ChannelManager.h
+++ b/ChannelManager.h
@@ -26,6 +26,7 @@ public:
 	void OnPulse();
 	void OnBeginZone();
 	void OnEndZone();
+	void OnZoned();
 
 	// channels
 	void JoinCustomChannel(std::string_view name, std::string_view autoArg = {});
@@ -50,6 +51,7 @@ private:
 
 	void UpdateGroupChannel();
 	void UpdateRaidChannel();
+	void UpdateZoneChannel();
 
 private:
 	std::string m_channelINISection;

--- a/MQRemote.cpp
+++ b/MQRemote.cpp
@@ -320,3 +320,8 @@ PLUGIN_API void OnEndZone()
 {
 	gChannels->OnEndZone();
 }
+
+PLUGIN_API void OnZoned()
+{
+	gChannels->OnZoned();
+}


### PR DESCRIPTION
This PR fixes the 'zone' channel so that it is always available. The current code only creates the zone channel during OnEndZone() but OnEndZone is called: "just after the loading screen, but prior to the zone being fully loaded" and so pZoneInfo is often not set. This resulted in the zone channel being available inconsistently. It would always be available if one unloaded and reloaded MQRemote, but it wouldn't be available after logging in with the plugin already loaded (the most common case if a plugin is enabled), and often not available after zoning, depending purely on random timing.

This patch moves the zone channel creation to a utility function that gets called during Initialize(), SetGameState() and OnZoned() to ensure the zone channel is always created properly.